### PR TITLE
Fix network error due to large data URL

### DIFF
--- a/kam1n0/kam1n0-apps/src/main/resources/static/js/dmas-elements.js
+++ b/kam1n0/kam1n0-apps/src/main/resources/static/js/dmas-elements.js
@@ -412,7 +412,7 @@ function CreateCloneList($container, dataParsed, callback, icons, views, viewnam
         	var wrapper = {'data':dataParsed, 'view': window.location.href }
         	$("<a />", {
         	    "download": "result.json",
-        	    "href" : "data:application/json," + encodeURIComponent(JSON.stringify(wrapper, null, 2))
+        	    "href" : URL.createObjectURL(new Blob([JSON.stringify(wrapper, null, 2)], {type: "application/octet-stream"}))
         	  }).appendTo("body")
         	  .click(function() {
         	     $(this).remove()


### PR DESCRIPTION
Steps to reproduce bug:
1. Open a results file
2. Click on a function
3. Clicking on the download button may trigger a network error

Here's a discussion related to the same type of issue: https://stackoverflow.com/questions/42958598/failed-network-error-when-trying-to-provide-download-in-html5-using-downloa