### PR TITLE
1. improve the way to determine idaapi version to avoid "ValueError: …

### DIFF
--- a/kam1n0-clients/ida-plugin/Kam1n0/IDAUtils.py
+++ b/kam1n0-clients/ida-plugin/Kam1n0/IDAUtils.py
@@ -37,7 +37,7 @@ ICONS = namedtuple("Icons", list(ALL_ICONS.keys()))
 
 
 def is_hexrays_v7():
-    return idaapi.cvar.inf.version >= 700
+    return idaapi.IDA_SDK_VERSION >= 700
 
 
 def _is_lib_func(func):

--- a/kam1n0-clients/ida-plugin/Kam1n0/Manager.py
+++ b/kam1n0-clients/ida-plugin/Kam1n0/Manager.py
@@ -54,7 +54,7 @@ class Kam1n0PluginManager:
             return ctx.form_title
 
     def setup_default_connection(self):
-        if self.configuration is not None:
+        if self.configuration is not None and len(self.configuration['apps']) > 0:
             if self.configuration['default-app'] is None:
                 self.connector = None
             else:
@@ -70,7 +70,8 @@ class Kam1n0PluginManager:
             self.configuration = dict()
             self.configuration['apps'] = {}
             self.configuration['default-app'] = None
-
+            self.connector = None
+            
         if 'default-threshold' not in self.configuration:
             self.configuration['default-threshold'] = 0.01
 

--- a/kam1n0-clients/ida-plugin/Kam1n0/forms/ConnectionManagementForm.py
+++ b/kam1n0-clients/ida-plugin/Kam1n0/forms/ConnectionManagementForm.py
@@ -146,7 +146,7 @@ Login Info:
                         self.configuration['default-app'] = \
                             self.configuration['apps'].keys()[0]
                     else:
-                        self.Kconf['default-cnn'] = None
+                        self.configuration['default-app'] = None
         self.updateDpList()
 
     def OnButtonUpdate(self, *_):


### PR DESCRIPTION
1. improve the way to determine idaapi version to avoid "ValueError: Invalid chooser passed" issue.

2. Fix the error with deleting the last connection in IDA Pro Plug-in.