### PR TITLE
include version for maven shade plugin as 3.2.1 in /kam1n0/kam1n0-cli/pom.xml

### DIFF
--- a/kam1n0/kam1n0-cli/pom.xml
+++ b/kam1n0/kam1n0-cli/pom.xml
@@ -29,6 +29,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.2.1</version>
 				<dependencies>
 					<dependency>
 						<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Since the current default version of maven-shade-plugin(3.2.3) has an [API change](https://github.com/spring-projects/spring-boot/issues/21128) that causes AbstractMethodError while building the source, adding the version of maven-shade-plugin to be 3.2.1 solves the error and build was successful.