### PR TITLE
GetReg is changed to get_sreg in idapro 7.4

### DIFF
--- a/kam1n0/kam1n0-commons/src/main/resources/ExtractBinaryViaIDA.py
+++ b/kam1n0/kam1n0-commons/src/main/resources/ExtractBinaryViaIDA.py
@@ -168,7 +168,7 @@ for seg_ea in Segments():
             sblock['id'] = bblock.id
             sblock['sea'] = bblock.start_ea
             if data['architecture']['type'] == 'arm':
-                sblock['sea'] += GetReg(bblock.start_ea, 'T')
+                sblock['sea'] += get_sreg(bblock.start_ea, 'T')
             sblock['eea'] = bblock.end_ea
             sblock['name'] = 'loc_' + format(bblock.start_ea, 'x').upper()
             dat = {}

--- a/kam1n0/kam1n0-resources/bin/ExtractBinaryViaIDA.py
+++ b/kam1n0/kam1n0-resources/bin/ExtractBinaryViaIDA.py
@@ -168,7 +168,7 @@ for seg_ea in Segments():
             sblock['id'] = bblock.id
             sblock['sea'] = bblock.start_ea
             if data['architecture']['type'] == 'arm':
-                sblock['sea'] += GetReg(bblock.start_ea, 'T')
+                sblock['sea'] += get_sreg(bblock.start_ea, 'T')
             sblock['eea'] = bblock.end_ea
             sblock['name'] = 'loc_' + format(bblock.start_ea, 'x').upper()
             dat = {}


### PR DESCRIPTION
In ExtractBinaryViaIDA.py, GetReg method is used for 'arm' binaries.
Porting from v6.x-7.3 to 7.4, IDAPro moved/renamed `GetReg` to `get_sreg` [(reference)](https://www.hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide.shtml)