### PR TITLE
docs: fix simple typo, missused -> misused

### DIFF
--- a/kam1n0/kam1n0-apps/src/main/resources/static/plugin/bootstrap-markdown/bootstrap-markdown.js
+++ b/kam1n0/kam1n0-apps/src/main/resources/static/plugin/bootstrap-markdown/bootstrap-markdown.js
@@ -468,7 +468,7 @@
           callbackContent;
 
       if (this.$isPreview == true) {
-        // Avoid sequenced element creation on missused scenario
+        // Avoid sequenced element creation on misused scenario
         // @see https://github.com/toopay/bootstrap-markdown/issues/170
         return this;
       }


### PR DESCRIPTION
There is a small typo in kam1n0/kam1n0-apps/src/main/resources/static/plugin/bootstrap-markdown/bootstrap-markdown.js.

Should read `misused` rather than `missused`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md